### PR TITLE
Fix nw-gyp compile errors

### DIFF
--- a/third_party/pdfium/pdfium.gyp
+++ b/third_party/pdfium/pdfium.gyp
@@ -15,6 +15,7 @@
       '_FPDFSDK_LIB',
       '_NO_GDIPLUS_',  # workaround text rendering issues on Windows
       'OPJ_STATIC',
+      'WIN32_LEAN_AND_MEAN',
     ],
     'include_dirs': [
       'third_party/freetype/include',


### PR DESCRIPTION
error c2011 'sockaddr' 'struct' type redefinition

http://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h
