### PR TITLE
Update for Node 7.*

### DIFF
--- a/src/node_pdfium.cc
+++ b/src/node_pdfium.cc
@@ -504,7 +504,9 @@ void EncodePagesResult(const std::vector<std::string>& iResult, v8::Handle<v8::A
   MY_NODE_MODULE_ISOLATE_DECL;
   int i = 0;
   for(std::vector<std::string>::const_iterator it = iResult.begin(); it != iResult.end(); ++it) {
-    v8::Local<v8::Value> data = node::Buffer::New(MY_NODE_MODULE_ISOLATE_PRE it->c_str(), it->size());
+    v8::MaybeLocal<v8::Object> objTemp = node::Buffer::New(MY_NODE_MODULE_ISOLATE_PRE (char*)it->c_str(), it->size());
+	v8::Local<v8::Value> data(objTemp.ToLocalChecked());
+	
     oResult->Set(i++, data);
   }
 }
@@ -575,10 +577,10 @@ MY_NODE_MODULE_CALLBACK(render)
   v8::String::Utf8Value outputFormatObject(options->Get(V8_STRING_NEW_UTF8("outputFormat"))->ToString());
   v8::Local<v8::Object> dataobject = options->Get(V8_STRING_NEW_UTF8("data")).As<v8::Object>();
 
-  if(dataobject->IsObject() && dataobject->HasIndexedPropertiesInExternalArrayData())
+  if(dataobject->IsObject() && dataobject->IsUint8Array())
   {
-    req->data.assign(static_cast<char*>(dataobject->GetIndexedPropertiesExternalArrayData()),
-            dataobject->GetIndexedPropertiesExternalArrayDataLength());
+    req->data.assign(static_cast<char*>(dataobject.As<v8::Uint16Array>()->Buffer()->GetContents().Data()),
+            dataobject.As<v8::Uint16Array>()->Length());
   }
   else
   {

--- a/third_party/pdfium/fpdfsdk/src/javascript/JS_Object.cpp
+++ b/third_party/pdfium/fpdfsdk/src/javascript/JS_Object.cpp
@@ -88,15 +88,18 @@ void CJS_EmbedObj::EndTimer(CJS_Timer* pTimer)
 }
 
 /* ---------------------------------  CJS_Object --------------------------------- */
-void  FreeObject(const v8::WeakCallbackData<v8::Object, CJS_Object>& data)
+void  FreeObject(const v8::WeakCallbackInfo<CJS_Object>& data/*, v8::Local<v8::Object> obj*/)
 {
 	CJS_Object* pJSObj  = data.GetParameter();
+
+	v8::Local<v8::Object> obj = pJSObj->operator JSFXObject();
+
 	if(pJSObj)
 	{
 		pJSObj->ExitInstance();
 		delete pJSObj;
 	}
-	v8::Local<v8::Object> obj = data.GetValue();
+
 	JS_FreePrivate(obj);
 }
 
@@ -117,7 +120,7 @@ CJS_Object::~CJS_Object(void)
 
 void	CJS_Object::MakeWeak()
 {
-	m_pObject.SetWeak(this, FreeObject);
+	m_pObject.SetWeak(this, FreeObject, v8::WeakCallbackType::kParameter);
 }
 
 CPDFSDK_PageView* CJS_Object::JSGetPageView(IFXJS_Context* cc)

--- a/third_party/pdfium/fpdfsdk/src/javascript/JS_Object.cpp
+++ b/third_party/pdfium/fpdfsdk/src/javascript/JS_Object.cpp
@@ -88,7 +88,7 @@ void CJS_EmbedObj::EndTimer(CJS_Timer* pTimer)
 }
 
 /* ---------------------------------  CJS_Object --------------------------------- */
-void  FreeObject(const v8::WeakCallbackInfo<CJS_Object>& data/*, v8::Local<v8::Object> obj*/)
+void  FreeObject(const v8::WeakCallbackInfo<CJS_Object>& data)
 {
 	CJS_Object* pJSObj  = data.GetParameter();
 

--- a/third_party/pdfium/fpdfsdk/src/javascript/JS_Runtime.cpp
+++ b/third_party/pdfium/fpdfsdk/src/javascript/JS_Runtime.cpp
@@ -100,7 +100,7 @@ CJS_Runtime::CJS_Runtime(CPDFDoc_Environment * pApp) :
 	m_pFieldEventPath(NULL),
 	m_bRegistered(FALSE)
 {
-	m_isolate = v8::Isolate::New();
+	m_isolate = v8::Isolate::GetCurrent();
 	//m_isolate->Enter();
 
 	InitJSObjects();

--- a/third_party/pdfium/fpdfsdk/src/jsapi/fxjs_v8.cpp
+++ b/third_party/pdfium/fpdfsdk/src/jsapi/fxjs_v8.cpp
@@ -758,13 +758,13 @@ double _getLocalTZA()
 	time_t t = 0;
 	time(&t);
 	localtime(&t);
-#if _MSC_VER >= 1900
-	// In gcc and in Visual Studio prior to VS 2015 'timezone' is a global
-	// variable declared in time.h. That variable was deprecated and in VS 2015
-	// is removed, with _get_timezone replacing it.
-	long timezone = 0;
-	_get_timezone(&timezone);
-#endif
+	#if _MSC_VER >= 1900
+		// In gcc and in Visual Studio prior to VS 2015 'timezone' is a global
+		// variable declared in time.h. That variable was deprecated and in VS 2015
+		// is removed, with _get_timezone replacing it.
+		long timezone = 0;
+		_get_timezone(&timezone);
+	#endif
 	return (double)(-(timezone * 1000));
 }
 


### PR DESCRIPTION
I had to work with this plugin and once I tried to build with node-gyp I encountered a issue due to node's version and removed methods (see #9, #12, #13)
I used this plugin with electron so I couldn't change node's version an I decided to update this plugin with the new V8 API.
What I did is change some removed method with the new one and, at least, modify some piece of code to adapt to new API.

This work it has been tested in my electron app and it works.